### PR TITLE
Add missing torch dependency

### DIFF
--- a/tangent-api/requirements.txt
+++ b/tangent-api/requirements.txt
@@ -8,3 +8,4 @@ umap-learn
 requests
 dataclasses-json
 python-dotenv
+torch


### PR DESCRIPTION
Add a missing torch dependency to fix:

```
(venv) (base) tangent-api % python src/app.py --embedding-model all-minilm --generation-model llama3.3
Traceback (most recent call last):
  File ".../tangent/tangent-api/src/app.py", line 3, in <module>
    from routes.api import api_bp
  File ".../tangent/tangent-api/src/routes/api.py", line 10, in <module>
    from torch import cosine_similarity
ModuleNotFoundError: No module named 'torch'
```